### PR TITLE
[12][IMP] port of pos_order_mgmt

### DIFF
--- a/pos_order_mgmt/__manifest__.py
+++ b/pos_order_mgmt/__manifest__.py
@@ -18,6 +18,7 @@
     'data': [
         'views/assets.xml',
         'views/view_pos_config.xml',
+        'views/view_pos_order.xml',
     ],
     'qweb': [
         'static/src/xml/pos.xml'

--- a/pos_order_mgmt/i18n/fr.po
+++ b/pos_order_mgmt/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-15 20:53+0000\n"
-"PO-Revision-Date: 2019-07-15 20:53+0000\n"
+"POT-Creation-Date: 2019-07-15 20:54+0000\n"
+"PO-Revision-Date: 2019-07-15 20:54+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,46 +18,46 @@ msgstr ""
 #. module: pos_order_mgmt
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Allow to duplicate done orders in this POS"
-msgstr ""
+msgstr "Autoriser à dupliquer des commandes réalisées dans l'interface tactile"
 
 #. module: pos_order_mgmt
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Allow to reprint done orders in this POS"
-msgstr ""
+msgstr "Autoriser à réimprimer des commandes réalisées dans l'interface tactile"
 
 #. module: pos_order_mgmt
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Allow to return done orders in this POS"
-msgstr ""
+msgstr "Autoriser à rembourser des commandes réalisées dans l'interface tactile"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,help:pos_order_mgmt.field_pos_config__iface_copy_done_order
 msgid "Allows to duplicate already done orders in the frontend"
-msgstr ""
+msgstr "Autoriser à dupliquer des commandes réalisées dans l'interface tactile"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,help:pos_order_mgmt.field_pos_config__iface_reprint_done_order
 msgid "Allows to reprint already done orders in the frontend"
-msgstr ""
+msgstr "Autoriser à réimprimer des commandes réalisées dans l'interface tactile"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,help:pos_order_mgmt.field_pos_config__iface_return_done_order
 msgid "Allows to return already done orders in the frontend"
-msgstr ""
+msgstr "Autoriser à rembourser des commandes réalisées dans l'interface tactile"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:36
 #, python-format
 msgid "Amount Total"
-msgstr ""
+msgstr "Total"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:17
 #, python-format
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
 #. module: pos_order_mgmt
 #. openerp-web
@@ -65,7 +65,7 @@ msgstr ""
 #: code:addons/pos_order_mgmt/static/src/js/widgets.js:396
 #, python-format
 msgid "Can not execute this action because the POS is currently offline"
-msgstr ""
+msgstr "Vous ne pouvez pas exécuter cette action, car le Point de Vente est actuellement hors ligne"
 
 #. module: pos_order_mgmt
 #. openerp-web
@@ -73,28 +73,28 @@ msgstr ""
 #: code:addons/pos_order_mgmt/static/src/js/widgets.js:395
 #, python-format
 msgid "Connection error"
-msgstr ""
+msgstr "Erreur de connexion"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:61
 #, python-format
 msgid "Create a new order based on this one"
-msgstr ""
+msgstr "Créer une nouvelle commande basée sur celle-ci"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:64
 #, python-format
 msgid "Create a refund order of this order"
-msgstr ""
+msgstr "Rembourser cette commande"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:34
 #, python-format
 msgid "Customer"
-msgstr ""
+msgstr "Client"
 
 #. module: pos_order_mgmt
 #. openerp-web
@@ -102,30 +102,30 @@ msgstr ""
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:98
 #, python-format
 msgid "DUPLICATE"
-msgstr ""
+msgstr "DUPLICATA"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:35
 #, python-format
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_config__iface_copy_done_order
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Duplicate Done Orders"
-msgstr ""
+msgstr "Copier une commande réalisées"
 
 #. module: pos_order_mgmt
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Load Done Order Max Qty."
-msgstr ""
+msgstr "Quantité maximale de commandes à charger"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_config__iface_load_done_order_max_qty
 msgid "Max. Done Orders Quantity To Load"
-msgstr ""
+msgstr "Quantité maximale de commandes à charger"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,help:pos_order_mgmt.field_pos_config__iface_load_done_order_max_qty
@@ -135,96 +135,96 @@ msgstr ""
 #. module: pos_order_mgmt
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Maximum number orders to load"
-msgstr ""
+msgstr "Nombre maximum de commande à charger"
 
 #. module: pos_order_mgmt
 #: model:ir.model,name:pos_order_mgmt.model_pos_config
 msgid "Point of Sale Configuration"
-msgstr ""
+msgstr "Paramétrage du point de vente"
 
 #. module: pos_order_mgmt
 #: model:ir.model,name:pos_order_mgmt.model_pos_order
 msgid "Point of Sale Orders"
-msgstr ""
+msgstr "Commandes du point de vente"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:58
 #, python-format
 msgid "Print a duplicate for this order"
-msgstr ""
+msgstr "Imprimer un duplicata de cette commande"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:83
 #, python-format
 msgid "Rectifies:"
-msgstr ""
+msgstr "Rectifie : "
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:33
 #, python-format
 msgid "Ref."
-msgstr ""
+msgstr "Réf."
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_order__returned_order_reference
 msgid "Reference of the returned Order"
-msgstr ""
+msgstr "Réference de la vente retournée"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/js/widgets.js:242
 #, python-format
 msgid "Refund "
-msgstr ""
+msgstr "Rembourse "
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_order__refund_order_ids
 msgid "Refund Orders"
-msgstr ""
+msgstr "Commandes remboursées"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_order__refund_order_qty
 msgid "Refund Orders Quantity"
-msgstr ""
+msgstr "Nombre de remboursement"
 
 #. module: pos_order_mgmt
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_order_form
 msgid "Refunds"
-msgstr ""
+msgstr "Remboursements"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_config__iface_reprint_done_order
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Reprint Done Orders"
-msgstr ""
+msgstr "Réimprimer le ticket d'une commande réalisée"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_config__iface_return_done_order
 #: model_terms:ir.ui.view,arch_db:pos_order_mgmt.view_pos_config_form
 msgid "Return Done Orders"
-msgstr ""
+msgstr "Retourner une commande réalisée"
 
 #. module: pos_order_mgmt
 #: model:ir.model.fields,field_description:pos_order_mgmt.field_pos_order__returned_order_id
 msgid "Returned Order"
-msgstr ""
+msgstr "Commande retournée"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:74
 #, python-format
 msgid "Returned order:"
-msgstr ""
+msgstr "Commande retournée:"
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/xml/pos.xml:21
 #, python-format
 msgid "Search Order"
-msgstr ""
+msgstr "Recherche une commande"
 
 #. module: pos_order_mgmt
 #. openerp-web
@@ -235,12 +235,15 @@ msgid "Unable to load some order lines because the products are not available in
 "Please check that lines :\n"
 "\n"
 "  * "
-msgstr ""
+msgstr "Impossible de charger certaines lignes de ticket car les produits ne sont pas disponible dans le point de vente\n"
+"Veuillez vérifier les lignes suivantes : \n"
+"\n"
+"  * "
 
 #. module: pos_order_mgmt
 #. openerp-web
 #: code:addons/pos_order_mgmt/static/src/js/widgets.js:357
 #, python-format
 msgid "Unknown Products"
-msgstr ""
+msgstr "Produit inconnu"
 

--- a/pos_order_mgmt/models/pos_config.py
+++ b/pos_order_mgmt/models/pos_config.py
@@ -14,14 +14,12 @@ class PosConfig(models.Model):
         string='Reprint Done Orders',
         default=True,
         help='Allows to reprint already done orders in the frontend',
-        oldname='iface_load_done_order',
     )
 
     iface_return_done_order = fields.Boolean(
         string='Return Done Orders',
         default=True,
         help='Allows to return already done orders in the frontend',
-        oldname='iface_load_done_order',
     )
 
     iface_copy_done_order = fields.Boolean(
@@ -35,6 +33,6 @@ class PosConfig(models.Model):
         default=10,
         required=True,
         help='Maximum number of orders to load on the PoS at its init. '
-             'Set it to 0 to load none (it\'s still posible to load them by '
+             'Set it to 0 to load none (it\'s still possible to load them by '
              'ticket code).',
     )

--- a/pos_order_mgmt/static/src/css/pos.css
+++ b/pos_order_mgmt/static/src/css/pos.css
@@ -31,4 +31,5 @@
     padding: 8px 0;
     background-color: rgb(239, 153, 65);
     color: white;
+    text-align: center;
 }

--- a/pos_order_mgmt/static/src/js/models.js
+++ b/pos_order_mgmt/static/src/js/models.js
@@ -6,40 +6,24 @@ odoo.define('pos_order_mgmt.models', function (require) {
 
     var models = require('point_of_sale.models');
 
-    var _PosModel_push_order = models.PosModel.prototype.push_order;
-    models.PosModel.prototype.push_order = function () {
-        var res = _PosModel_push_order.apply(this, arguments);
-        if (arguments.length && arguments[0] && arguments[0].uid) {
-            var order = this.db.get_order(arguments[0].uid);
-            if (order && order.data) {
-                var data = _.extend({}, order.data);
-                var partner = this.db.get_partner_by_id(data.partner_id);
-                if (partner && partner.id && partner.name) {
-                    data.partner_id = [partner.id, partner.name];
-                }
-                data.date_order = moment(order.data.creation_date)
-                    .format('YYYY-MM-DD HH:mm:ss');
-                this.gui.screen_instances.orderlist.orders.unshift(data);
-            }
-        }
-        return res;
-    };
-
     var order_super = models.Order.prototype;
+
     models.Order = models.Order.extend({
         init_from_JSON: function (json) {
             order_super.init_from_JSON.apply(this, arguments);
-            this.return = json.return;
             this.returned_order_id = json.returned_order_id;
-            this.origin_name = json.origin_name;
+            this.returned_order_reference = json.returned_order_reference;
         },
         export_as_JSON: function () {
             var res = order_super.export_as_JSON.apply(this, arguments);
-            if (this.return) {
-                res.origin_name = this.origin_name;
-                res.returned_order_id = this.returned_order_id;
-                res.return = this.return;
-            }
+            res.returned_order_id = this.returned_order_id;
+            res.returned_order_reference = this.returned_order_reference;
+            return res;
+        },
+        export_for_printing: function () {
+            var res = order_super.export_for_printing.apply(this, arguments);
+            res.returned_order_id = this.returned_order_id;
+            res.returned_order_reference = this.returned_order_reference;
             return res;
         },
     });

--- a/pos_order_mgmt/static/src/xml/pos.xml
+++ b/pos_order_mgmt/static/src/xml/pos.xml
@@ -55,13 +55,13 @@
             <td name="td_ol_date"><t t-esc='order.date_order' /></td>
             <td name="td_ol_amount_total"><t t-esc='widget.format_currency(order.amount_total)' /></td>
             <td name="td_ol_reprint" t-att-data-order-id="order.id" t-att-data-Uid='order.uid'>
-                <span t-if="widget.pos.config.iface_reprint_done_order" class="button order-list-reprint" t-att-data-order-id="order.id" t-att-data-Uid='order.uid'>
+                <span t-if="widget.pos.config.iface_reprint_done_order" class="button order-list-reprint" t-att-data-order-id="order.id" t-att-data-Uid='order.uid' title="Print a duplicate for this order">
                     <i class='fa fa-fw fa-print'/>
                 </span>
-                <span t-if="widget.pos.config.iface_copy_done_order" class="button order-list-copy" t-att-data-order-id="order.id" t-att-data-Uid='order.uid'>
+                <span t-if="widget.pos.config.iface_copy_done_order" class="button order-list-copy" t-att-data-order-id="order.id" t-att-data-Uid='order.uid' title="Create a new order based on this one">
                     <i class='fa fa-fw fa-copy'/>
                 </span>
-                <span t-if="widget.pos.config.iface_return_done_order and order.amount_total >= 0" class="button order-list-return" t-att-data-order-id="order.id" t-att-data-Uid='order.uid'>
+                <span t-if="widget.pos.config.iface_return_done_order and order.amount_total >= 0" class="button order-list-return" t-att-data-order-id="order.id" t-att-data-Uid='order.uid' title="Create a refund order of this order">
                     <i class='fa fa-fw fa-undo'/>
                 </span>
             </td>
@@ -69,18 +69,18 @@
     </t>
 
     <t t-extend="OrderWidget">
-        <t t-jquery=".order-scroller.touch-scrollable" t-operation="before">
-            <div class="order-returned-warning" t-if="order.return">
-                <span>Returned order: </span><t name="order-return-uid" t-esc="order.origin_name"></t>
+        <t t-jquery=".summary" t-operation="after">
+            <div class="order-returned-warning" t-if="order.returned_order_id">
+                <span>Returned order: </span><t name="returned-order-reference" t-esc="order.returned_order_reference"></t>
             </div>
         </t>
     </t>
 
     <t t-extend="PosTicket">
         <t t-jquery="t[t-esc='order.name']" t-operation="after">
-            <t t-if="order.origin_name">
+            <t t-if="order.returned_order_id">
                 <br/>
-                    <span name="order-origin-name">Rectifies: </span><t t-esc="order.origin_name"/>
+                    <span name="returned-order-reference">Rectifies: </span><t t-esc="order.returned_order_reference"/>
             </t>
         </t>
         <t t-jquery=".receipt-user" t-operation="after">

--- a/pos_order_mgmt/tests/__init__.py
+++ b/pos_order_mgmt/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_module

--- a/pos_order_mgmt/tests/test_module.py
+++ b/pos_order_mgmt/tests/test_module.py
@@ -1,0 +1,80 @@
+# Copyright (C) 2019 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+
+class TestModule(TransactionCase):
+
+    def setUp(self):
+        super(TestModule, self).setUp()
+
+        # Get Registry
+        self.PosOrder = self.env['pos.order']
+        self.AccountPayment = self.env['account.payment']
+
+        # Get Object
+        self.pos_product = self.env.ref('point_of_sale.whiteboard_pen')
+        self.pricelist = self.env.ref('product.list0')
+        self.partner = self.env.ref('base.res_partner_12')
+
+        # Create a new pos config and open it
+        self.pos_config = self.env.ref('point_of_sale.pos_config_main').copy()
+        self.pos_config.open_session_cb()
+
+    # Test Section
+    def test_load_order(self):
+        order = self._create_order()
+        orders_data = self.PosOrder.search_done_orders_for_pos(
+            [], self.pos_config.current_session_id.id)
+        self.assertEqual(len(orders_data), 1)
+        self.assertEqual(
+            orders_data[0]['id'], order.id)
+
+        detail_data = order.load_done_order_for_pos()
+        self.assertEqual(
+            len(detail_data.get('line_ids', [])), 1,
+            "Loading order detail failed")
+
+    def _create_order(self):
+        # Create order
+        order_data = {
+            'id': u'0006-001-0010',
+            'to_invoice': True,
+            'data': {
+                'pricelist_id': self.pricelist.id,
+                'user_id': 1,
+                'name': 'Order 0006-001-0010',
+                'partner_id': self.partner.id,
+                'amount_paid': 0.9,
+                'pos_session_id': self.pos_config.current_session_id.id,
+                'lines': [[0, 0, {
+                    'product_id': self.pos_product.id,
+                    'price_unit': 0.9,
+                    'qty': 1,
+                    'price_subtotal': 0.9,
+                    'price_subtotal_incl': 0.9,
+                }]],
+                'statement_ids': [[0, 0, {
+                    'journal_id': self.pos_config.journal_ids[0].id,
+                    'amount': 0.9,
+                    'name': fields.Datetime.now(),
+                    'account_id':
+                    self.env.user.partner_id.property_account_receivable_id.id,
+                    'statement_id':
+                    self.pos_config.current_session_id.statement_ids[0].id,
+                }]],
+                'creation_date': u'2018-09-27 15:51:03',
+                'amount_tax': 0,
+                'fiscal_position_id': False,
+                'uid': u'00001-001-0001',
+                'amount_return': 0,
+                'sequence_number': 1,
+                'amount_total': 0.9,
+            }}
+
+        result = self.PosOrder.create_from_ui([order_data])
+        order = self.PosOrder.browse(result[0])
+        return order

--- a/pos_order_mgmt/views/view_pos_config.xml
+++ b/pos_order_mgmt/views/view_pos_config.xml
@@ -6,7 +6,6 @@
 <odoo>
 
     <record id="view_pos_config_form" model="ir.ui.view">
-        <field name="name">pos.config.form</field>
         <field name="model">pos.config</field>
         <field name="inherit_id" ref="point_of_sale.pos_config_view_form"/>
         <field name="arch" type="xml">

--- a/pos_order_mgmt/views/view_pos_order.xml
+++ b/pos_order_mgmt/views/view_pos_order.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 GRAP - Sylvain LE GAL
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_pos_order_form" model="ir.ui.view">
+        <field name="model">pos.order</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_pos_form"/>
+        <field name="arch" type="xml">
+            <field name="session_id" position="after">
+                <field name="returned_order_id" attrs="{'invisible': [('returned_order_id', '=', False)]}" />
+            </field>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_view_refund_orders" type="object" icon="fa-undo" class="oe_stat_button" attrs="{'invisible': [('refund_order_qty', '=', 0)]}">
+                    <field string="Refunds" name="refund_order_qty" widget="statinfo"/>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Hello @PierrickBrun, 

I did some improvements and fixes of your PR porting pos_order_mgmt. You can test the changes on the runbot here : https://github.com/OCA/pos/pull/373

Could you integrate that changes ?

thanks ! 

[FIX] loaded orders date to local https://github.com/OCA/pos/pull/361cortesy @chienandalu
[FIX] compatibility with pos_restaurant https://github.com/OCA/pos/pull/339 cortesy @carlosDomatix
[FIX] add _compute_refund_order_qty
[ADD] pos order view form. Add links to original returned order and refund orders.
[IMP] when refunding an order via the 'Refund' button in back office, set the correct returned_order_id.
[IMP] Add helper on each button
[ADD] python test
[REF] JS remove useless code
[REF] Python remove useless code
[FIX] remove bad oldname
[FIX] remove gap in bill display, when it is a refund
[FIX] when reprinting a bill, the returned order name is displayed, if any
[FIX] JS lint, with OCA eslint file
[ADD] french translation

